### PR TITLE
Fix run on 64bit

### DIFF
--- a/tcp_listener/tcp_listener.c
+++ b/tcp_listener/tcp_listener.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <pthread.h>
+#include <sys/time.h>
 
 #if defined (__WIN32__)
 	#include <winsock2.h>
@@ -17,6 +18,7 @@
 	#include <netdb.h>
 	#include <sys/socket.h>
 	#include <netinet/in.h>
+    #include <arpa/inet.h>
 #endif
 
 typedef struct t_sockIo {


### PR DESCRIPTION
The missing includes causes the compiler to not have the correct sizings on 64bit systems.
It will then cause segfault with trying to connect to in TCP.
I add two missing includes to avoid that issue.
Fixed and tryied on : osx 64bit, linux 64bit and seems to be ok.