### PR TITLE
Add command line option to output packet timing information

### DIFF
--- a/aisdecoder/aisdecoder.c
+++ b/aisdecoder/aisdecoder.c
@@ -151,7 +151,7 @@ int send_nmea( const char *sentence, unsigned int length) {
         return 0;
 }
 
-int init_ais_decoder(char * host, char * port ,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time){
+int init_ais_decoder(char * host, char * port ,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time, int add_sample_num){
 	debug_nmea=_debug_nmea;
 	use_tcp = use_tcp_listener;
 	pthread_mutex_init(&message_mutex, NULL);
@@ -171,7 +171,7 @@ int init_ais_decoder(char * host, char * port ,int show_levels,int _debug_nmea,i
 	}
     if (show_levels) on_sound_level_changed=sound_level_changed;
     on_nmea_sentence_received=nmea_sentence_received;
-	initSoundDecoder(buf_len,time_print_stats); 
+	initSoundDecoder(buf_len,time_print_stats,add_sample_num); 
 	return 0;
 }	
 

--- a/aisdecoder/aisdecoder.h
+++ b/aisdecoder/aisdecoder.h
@@ -1,6 +1,6 @@
 #ifndef __AIS_RL_AIS_INC_
 #define  __AIS_RL_AIS_INC_
-int init_ais_decoder(char * host, char * port,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time);
+int init_ais_decoder(char * host, char * port,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time, int add_sample_num);
 void run_rtlais_decoder(short * buff, int len);
 const char *aisdecoder_next_message();
 int free_ais_decoder(void);

--- a/aisdecoder/lib/protodec.c
+++ b/aisdecoder/lib/protodec.c
@@ -211,13 +211,14 @@ void protodec_generate_nmea(struct demod_state_t *d, int bufferlen, int fillbits
         nmeachk = d->nmea[m++];
         while (d->nmea[m] != '*') nmeachk ^= d->nmea[m++];
 
+        int inc;
         if (d->add_sample_num){
-            sprintf(&d->nmea[k + 3], "%02X,%lu\r\n", nmeachk, d->startsample);
+            inc = sprintf(&d->nmea[k + 3], "%02X,%lu\r\n", nmeachk, d->startsample);
         }else{
-            sprintf(&d->nmea[k + 3], "%02X\r\n", nmeachk);
+            inc = sprintf(&d->nmea[k + 3], "%02X\r\n", nmeachk);
         }
         if (on_nmea_sentence_received != NULL)
-            on_nmea_sentence_received(d->nmea, k+7, sentences, sentencenum);
+            on_nmea_sentence_received(d->nmea, k+3+inc, sentences, sentencenum);
     } while (sentencenum < sentences);
 }
 

--- a/aisdecoder/lib/protodec.c
+++ b/aisdecoder/lib/protodec.c
@@ -34,7 +34,7 @@ decoder_on_nmea_sentence_received on_nmea_sentence_received=NULL;
 #include <dmalloc.h>
 #endif
 
-void protodec_initialize(struct demod_state_t *d, struct serial_state_t *serial, char chanid)
+void protodec_initialize(struct demod_state_t *d, struct serial_state_t *serial, char chanid, int add_sample_num)
 {
 	memset(d, 0, sizeof(struct demod_state_t));
 
@@ -48,6 +48,7 @@ void protodec_initialize(struct demod_state_t *d, struct serial_state_t *serial,
 	protodec_reset(d);
 	
 	d->seqnr = 0;
+    d->add_sample_num = add_sample_num;
 	
     d->buffer = hmalloc(DEMOD_BUFFER_LEN);
     d->rbuffer = hmalloc(DEMOD_BUFFER_LEN);
@@ -210,7 +211,11 @@ void protodec_generate_nmea(struct demod_state_t *d, int bufferlen, int fillbits
         nmeachk = d->nmea[m++];
         while (d->nmea[m] != '*') nmeachk ^= d->nmea[m++];
 
-        sprintf(&d->nmea[k + 3], "%02X\r\n", nmeachk);
+        if (d->add_sample_num){
+            sprintf(&d->nmea[k + 3], "%02X,%lu\r\n", nmeachk, d->startsample);
+        }else{
+            sprintf(&d->nmea[k + 3], "%02X\r\n", nmeachk);
+        }
         if (on_nmea_sentence_received != NULL)
             on_nmea_sentence_received(d->nmea, k+7, sentences, sentencenum);
     } while (sentencenum < sentences);
@@ -245,7 +250,7 @@ void protodec_getdata(int bufferlen, struct demod_state_t *d)
 		return; // unsupported packet type
 }
 
-void protodec_decode(char *in, int count, struct demod_state_t *d)
+void protodec_decode(char *in, int count, struct demod_state_t *d, unsigned long samplenum)
 {
 	int i = 0;
 	int bufferlength, correct;
@@ -330,6 +335,7 @@ void protodec_decode(char *in, int count, struct demod_state_t *d)
 			if (d->nstartsign >= 7) {
 				if (in[i] == 0) {
 					d->state = ST_DATA;
+                    d->startsample = samplenum;
 					d->nstartsign = 0;
 					d->antallenner = 0;
 					memset(d->buffer, 0, DEMOD_BUFFER_LEN);

--- a/aisdecoder/lib/protodec.h
+++ b/aisdecoder/lib/protodec.h
@@ -31,7 +31,7 @@
 
 #define DEMOD_BUFFER_LEN 450
 #define MAX_AIS_PACKET_TYPE 27
-#define NMEABUFFER_LEN 100
+#define NMEABUFFER_LEN 128
 
 struct demod_state_t {
 	char chanid;
@@ -51,15 +51,18 @@ struct demod_state_t {
 	int lostframes;
 	int lostframes2;
 	unsigned char seqnr;
-	
+
+    unsigned long startsample;
+    int add_sample_num;
+
 	struct serial_state_t *serial;
 	
 	char *nmea;
 };
 
-void protodec_initialize(struct demod_state_t *d, struct serial_state_t *serial, char chanid);
+void protodec_initialize(struct demod_state_t *d, struct serial_state_t *serial, char chanid, int add_sample_num);
 void protodec_reset(struct demod_state_t *d);
 void protodec_getdata(int bufferlengde, struct demod_state_t *d);
-void protodec_decode(char *in, int count, struct demod_state_t *d);
+void protodec_decode(char *in, int count, struct demod_state_t *d, unsigned long samplenum);
 
 #endif

--- a/aisdecoder/lib/receiver.h
+++ b/aisdecoder/lib/receiver.h
@@ -46,9 +46,10 @@ struct receiver {
 	struct demod_state_t *decoder;
 	int prev;
 	time_t last_levellog;
+    unsigned long samplenum;
 };
 
-extern struct receiver *init_receiver(char name, int num_ch, int ch_ofs);
+extern struct receiver *init_receiver(char name, int num_ch, int ch_ofs, int add_sample_num);
 extern void free_receiver(struct receiver *rx);
 
 extern void receiver_run(struct receiver *rx, short *buf, int len);

--- a/aisdecoder/sounddecoder.c
+++ b/aisdecoder/sounddecoder.c
@@ -45,15 +45,15 @@ static void readBuffers();
 static time_t tprev=0;
 static int time_print_stats=0;
 
-int initSoundDecoder(int buf_len,int _time_print_stats) 
+int initSoundDecoder(int buf_len,int _time_print_stats, int add_sample_num) 
 {
 	sound_channels=SOUND_CHANNELS_STEREO;
 	channels = sound_channels == SOUND_CHANNELS_MONO ? 1 : 2;
 	time_print_stats=_time_print_stats;
 	tprev=time(NULL); // for decoder statistics
     buffer = (short *) hmalloc(channels*sizeof(short)*buf_len);
-    rx_a = init_receiver('A', 2, 0);
-    rx_b = init_receiver('B', 2, 1);
+    rx_a = init_receiver('A', 2, 0, add_sample_num);
+    rx_b = init_receiver('B', 2, 1, add_sample_num);
     return 1;
 }
 

--- a/aisdecoder/sounddecoder.h
+++ b/aisdecoder/sounddecoder.h
@@ -26,7 +26,7 @@ typedef enum {
 } Sound_Driver;
 
 extern char errorSoundDecoder[];
-int initSoundDecoder(int buf_len,int _time_print_stats);
+int initSoundDecoder(int buf_len,int _time_print_stats, int add_sample_num);
 void runSoundDecoder(int *stop);
 void freeSoundDecoder(void);
 void run_mem_decoder(short * buf, int len,int max_buf_len);

--- a/main.c
+++ b/main.c
@@ -55,6 +55,7 @@ void usage(void)
 		"\t[-T use TCP communication, rtl-ais is tcp server ( -h is ignored)\n"
 		"\t[-t time to keep ais messages in sec, using tcp listener (default: 15)\n"
 		"\t[-n log NMEA sentences to console (stderr) (default off)]\n"
+		"\t[-I add sample index to NMEA messages (default off)]\n"
 		"\t[-L log sound levels to console (stderr) (default off)]\n\n"
 		"\t[-S seconds_for_decoder_stats (default 0=off)]\n\n"
 		"\tWhen the built-in AIS decoder is disabled the samples are sent to\n"
@@ -103,7 +104,7 @@ int main(int argc, char **argv)
         config.host = strdup("127.0.0.1");
         config.port = strdup("10110");
         
-	while ((opt = getopt(argc, argv, "l:r:s:o:EODd:g:p:RATt:P:h:nLS:?")) != -1)
+	while ((opt = getopt(argc, argv, "l:r:s:o:EODd:g:p:RATIt:P:h:nLS:?")) != -1)
 	{
 		switch (opt) {
 		case 'l':
@@ -144,6 +145,9 @@ int main(int argc, char **argv)
 		case 'A':
 			config.use_internal_aisdecoder=0;
 			break;
+        case 'I':
+            config.add_sample_num = 1;
+            break;
 		case 'P':
 			config.port=strdup(optarg);
 			break;

--- a/rtl_ais.c
+++ b/rtl_ais.c
@@ -481,6 +481,8 @@ void rtl_ais_default_config(struct rtl_ais_config *config)
         config->port=NULL;
 
         config->filename = "-";
+
+        config->add_sample_num = 0;
 }
 
 struct rtl_ais_context *rtl_ais_start(struct rtl_ais_config *config)
@@ -587,7 +589,7 @@ struct rtl_ais_context *rtl_ais_start(struct rtl_ais_config *config)
 		}
 	}
 	else{ // Internal AIS decoder
-            int ret=init_ais_decoder(config->host,config->port,config->show_levels,config->debug_nmea,ctx->stereo.bl_len,config->seconds_for_decoder_stats, config->use_tcp_listener, config->tcp_keep_ais_time);
+            int ret=init_ais_decoder(config->host,config->port,config->show_levels,config->debug_nmea,ctx->stereo.bl_len,config->seconds_for_decoder_stats, config->use_tcp_listener, config->tcp_keep_ais_time, config->add_sample_num);
 		if(ret != 0){
 			fprintf(stderr,"Error initializing built-in AIS decoder\n");
 			rtlsdr_cancel_async(ctx->dev);

--- a/rtl_ais.h
+++ b/rtl_ais.h
@@ -31,6 +31,8 @@ struct rtl_ais_config
     /* Aisdecoder */
     int	show_levels, debug_nmea;
     char *port, *host, *filename;
+
+    int add_sample_num;
 };
 
 struct rtl_ais_context;


### PR DESCRIPTION
Hello,

Timing is an important part of the AIS protocol. The current rtl_ais program loses the packet reception timestamp. This pull request adds a command line parameter (-I) to append a 48kHz counter to the NMEA message.

Sincerely,
Bertold