### PR TITLE
This is not a PR !!

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,4 @@
+
 ----------------------------------------------------------------------
 rtl_ais, a simple AIS tuner  and generic dual-frequency FM demodulator
 OS: Linux-Windows-OSX.


### PR DESCRIPTION
Sorry but couldn't create an "Issue", so trying this way instead.

I really like this software and have written a blogpost about it for some time ago [https://pysselilivet.blogspot.com/2018/06/ais-reciever-for-raspberry.html](https://pysselilivet.blogspot.com/2018/06/ais-reciever-for-raspberry.html)

but now there are two issues on RPi 4 and buster

1/ A bug which soon will be fixed https://github.com/raspberrypi/linux/issues/3060
2/ I'm a C newbie and can't compile the code, but it works nice on RPi 3 and Stretch. Please check log below. Any ideas ?

i@raspberrypi:~/rtl-ais $ make
cc main.o rtl_ais.o convenience.o ./aisdecoder/aisdecoder.o ./aisdecoder/sounddecoder.o ./aisdecoder/lib/receiver.o ./aisdecoder/lib/protodec.o ./aisdecoder/lib/hmalloc.o ./aisdecoder/lib/filter.o ./tcp_listener/tcp_listener.o -o rtl_ais -lpthread -lm -L -lrtlsdr
/usr/bin/ld: rtl_ais.o: in function `rtlsdr_thread_fn':
/home/pi/rtl-ais/rtl_ais.c:368: undefined reference to `rtlsdr_read_async'
/usr/bin/ld: rtl_ais.o: in function `rtl_ais_start':
/home/pi/rtl-ais/rtl_ais.c:570: undefined reference to `rtlsdr_open'
/usr/bin/ld: /home/pi/rtl-ais/rtl_ais.c:610: undefined reference to `rtlsdr_set_agc_mode'
/usr/bin/ld: /home/pi/rtl-ais/rtl_ais.c:595: undefined reference to `rtlsdr_cancel_async'
/usr/bin/ld: /home/pi/rtl-ais/rtl_ais.c:596: undefined reference to `rtlsdr_close'
/usr/bin/ld: rtl_ais.o: in function `rtl_ais_cleanup':
/home/pi/rtl-ais/rtl_ais.c:657: undefined reference to `rtlsdr_cancel_async'
/usr/bin/ld: /home/pi/rtl-ais/rtl_ais.c:668: undefined reference to `rtlsdr_cancel_async'
/usr/bin/ld: /home/pi/rtl-ais/rtl_ais.c:673: undefined reference to `rtlsdr_close'
/usr/bin/ld: convenience.o: in function `nearest_gain':
/home/pi/rtl-ais/convenience.c:116: undefined reference to `rtlsdr_set_tuner_gain_mode'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:121: undefined reference to `rtlsdr_get_tuner_gains'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:126: undefined reference to `rtlsdr_get_tuner_gains'
/usr/bin/ld: convenience.o: in function `verbose_set_frequency':
/home/pi/rtl-ais/convenience.c:142: undefined reference to `rtlsdr_set_center_freq'
/usr/bin/ld: convenience.o: in function `verbose_set_sample_rate':
/home/pi/rtl-ais/convenience.c:154: undefined reference to `rtlsdr_set_sample_rate'
/usr/bin/ld: convenience.o: in function `verbose_direct_sampling':
/home/pi/rtl-ais/convenience.c:166: undefined reference to `rtlsdr_set_direct_sampling'
/usr/bin/ld: convenience.o: in function `verbose_offset_tuning':
/home/pi/rtl-ais/convenience.c:183: undefined reference to `rtlsdr_set_offset_tuning'
/usr/bin/ld: convenience.o: in function `verbose_auto_gain':
/home/pi/rtl-ais/convenience.c:195: undefined reference to `rtlsdr_set_tuner_gain_mode'
/usr/bin/ld: convenience.o: in function `verbose_gain_set':
/home/pi/rtl-ais/convenience.c:207: undefined reference to `rtlsdr_set_tuner_gain_mode'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:212: undefined reference to `rtlsdr_set_tuner_gain'
/usr/bin/ld: convenience.o: in function `verbose_ppm_set':
/home/pi/rtl-ais/convenience.c:226: undefined reference to `rtlsdr_set_freq_correction'
/usr/bin/ld: convenience.o: in function `verbose_ppm_eeprom':
/home/pi/rtl-ais/convenience.c:241: undefined reference to `rtlsdr_get_usb_strings'
/usr/bin/ld: convenience.o: in function `verbose_reset_buffer':
/home/pi/rtl-ais/convenience.c:266: undefined reference to `rtlsdr_reset_buffer'
/usr/bin/ld: convenience.o: in function `verbose_device_search':
/home/pi/rtl-ais/convenience.c:277: undefined reference to `rtlsdr_get_device_count'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:284: undefined reference to `rtlsdr_get_device_usb_strings'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:297: undefined reference to `rtlsdr_get_device_usb_strings'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:301: undefined reference to `rtlsdr_get_device_name'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:307: undefined reference to `rtlsdr_get_device_usb_strings'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:317: undefined reference to `rtlsdr_get_device_usb_strings'
/usr/bin/ld: /home/pi/rtl-ais/convenience.c:324: undefined reference to `rtlsdr_get_device_name'
collect2: error: ld returned 1 exit status
make: *** [Makefile:56: rtl_ais] Error 1