### PR TITLE
treewide: Remove bzero and usleep

### DIFF
--- a/main.c
+++ b/main.c
@@ -216,6 +216,7 @@ int main(int argc, char **argv)
 	  nmea_sentence_received() in aidecoder.c 
 	  */
 	while(!do_exit && rtl_ais_isactive(ctx)) {
+		struct timespec five = { 0, 50 * 1000 * 1000};
 		const char *str;
 		if(config.use_internal_aisdecoder)
 		{
@@ -225,7 +226,7 @@ int main(int argc, char **argv)
 				//puts(str); or code something that fits your needs
 			}
 		}
-            usleep(50000);
+		nanosleep(&five, NULL);
         }
         rtl_ais_cleanup(ctx);
         return 0;

--- a/tcp_listener/tcp_listener.c
+++ b/tcp_listener/tcp_listener.c
@@ -87,7 +87,7 @@ int initTcpSocket(const char *portnumber, int debug_nmea, int tcp_keep_ais_time)
 		fprintf(stderr, "Failed to create socket! error %d\n", errno);
 		return 0;
 	}
-	bzero((char *) &serv_addr, sizeof(serv_addr));
+	memset((char *) &serv_addr, 0, sizeof(serv_addr));
 	portno = atoi(portnumber);
 	serv_addr.sin_family = AF_INET;
 	serv_addr.sin_addr.s_addr = INADDR_ANY;


### PR DESCRIPTION
Both were removed in POSIX 2008 and are optionally unavailable with
uClibc-ng.

Signed-off-by: Rosen Penev <rosenp@gmail.com>