### PR TITLE
New feature: `-k` flag (keep streaming new data to TCP connections)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,38 +5,30 @@ LDFLAGS+=-lpthread -lm
 ifeq ($(PREFIX),)
     PREFIX := /usr/local
 endif
+
 UNAME := $(shell uname)
 ifeq ($(UNAME),Linux)
-#Conditional for Linux
-CFLAGS+= $(shell pkg-config --cflags librtlsdr)
-LDFLAGS+=$(shell pkg-config --libs librtlsdr)
-
+	CFLAGS += $(shell pkg-config --cflags librtlsdr libusb-1.0)
+	LDFLAGS +=$(shell pkg-config --libs librtlsdr libusb-1.0)
+else ifeq ($(UNAME),Darwin)
+	CFLAGS += $(shell pkg-config --cflags librtlsdr libusb-1.0)
+	LDFLAGS += $(shell pkg-config --libs librtlsdr libusb-1.0)
 else
-#
-#ADD THE CORRECT PATH FOR LIBUSB AND RTLSDR
-#TODO:
-#    CMAKE will be much better or create a conditional pkg-config
+	#ADD THE CORRECT PATH FOR LIBUSB AND RTLSDR
+	#TODO:
+	#    CMAKE will be much better or create a conditional pkg-config
 
+	# RTLSDR
+	RTLSDR_INCLUDE=/tmp/rtl-sdr/include
+	RTLSDR_LIB=/tmp/rtl-sdr/build/src
 
-# RTLSDR
-RTLSDR_INCLUDE=/tmp/rtl-sdr/include
-RTLSDR_LIB=/tmp/rtl-sdr/build/src
+	# LIBUSB
+	LIBUSB_INCLUDE=/opt/homebrew/Cellar/libusb/1.0.24/include
+	LIBUSB_LIB=/opt/homebrew/Cellar/libusb/1.0.24/lib
 
-# LIBUSB
-LIBUSB_INCLUDE=/tmp/libusb/include/libusb-1.0
-LIBUSB_LIB=/tmp/libusb/lib
-
-ifeq ($(UNAME),Darwin)
-#Conditional for OSX
-CFLAGS+= -I/usr/local/include/ -I$(LIBUSB_INCLUDE) -I$(RTLSDR_INCLUDE)
-LDFLAGS+= -L/usr/local/lib -L$(LIBUSB_LIB) -L$(RTLSDR_LIB) -lrtlsdr -lusb-1.0 
-else
-#Conditional for Windows
-CFLAGS+=-I $(LIBUSB_INCLUDE) -I $(RTLSDR_INCLUDE)
-LDFLAGS+=-L$(LIBUSB_INCLUDE) -L$(RTLSDR_LIB) -L/usr/lib -lusb-1.0 -lrtlsdr -lWs2_32
-endif
-
-
+	#Conditional for Windows
+	CFLAGS+=-I $(LIBUSB_INCLUDE) -I $(RTLSDR_INCLUDE)
+	LDFLAGS+=-L$(LIBUSB_INCLUDE) -L$(RTLSDR_LIB) -L/usr/lib -lusb-1.0 -lrtlsdr -lWs2_32
 endif
 
 CC?=gcc

--- a/aisdecoder/aisdecoder.c
+++ b/aisdecoder/aisdecoder.c
@@ -151,7 +151,7 @@ int send_nmea( const char *sentence, unsigned int length) {
         return 0;
 }
 
-int init_ais_decoder(char * host, char * port ,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time, int add_sample_num){
+int init_ais_decoder(char * host, char * port ,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time, int tcp_stream_forever, int add_sample_num){
 	debug_nmea=_debug_nmea;
 	use_tcp = use_tcp_listener;
 	pthread_mutex_init(&message_mutex, NULL);
@@ -165,7 +165,7 @@ int init_ais_decoder(char * host, char * port ,int show_levels,int _debug_nmea,i
 		}
 	}
 	else {
-		if (!initTcpSocket(port, debug_nmea, tcp_keep_ais_time)) {
+		if (!initTcpSocket(port, debug_nmea, tcp_keep_ais_time, tcp_stream_forever)) {
 			return EXIT_FAILURE;
 		}
 	}

--- a/aisdecoder/aisdecoder.h
+++ b/aisdecoder/aisdecoder.h
@@ -1,6 +1,6 @@
 #ifndef __AIS_RL_AIS_INC_
 #define  __AIS_RL_AIS_INC_
-int init_ais_decoder(char * host, char * port,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time, int add_sample_num);
+int init_ais_decoder(char * host, char * port,int show_levels,int _debug_nmea,int buf_len,int time_print_stats, int use_tcp_listener, int tcp_keep_ais_time, int tcp_stream_forever, int add_sample_num);
 void run_rtlais_decoder(short * buff, int len);
 const char *aisdecoder_next_message();
 int free_ais_decoder(void);

--- a/aisdecoder/lib/protodec.c
+++ b/aisdecoder/lib/protodec.c
@@ -163,7 +163,7 @@ void protodec_generate_nmea(struct demod_state_t *d, int bufferlen, int fillbits
     int inc;
 
     unsigned char sentences, sentencenum, nmeachk, letter;
-    received_t=received_t; // not used here, avoid compiling warnings
+    (void)(received_t); // not used here, avoid compiling warnings
 	//6bits to nmea-ascii. One sentence len max 82char
 	//inc. head + tail.This makes inside datamax 62char multipart, 62 single
     senlen = 56;		//this is normally not needed.For testing only. May be fixed number

--- a/main.c
+++ b/main.c
@@ -55,6 +55,7 @@ void usage(void)
 		"\t[-P port (default: 10110)]\n"
 		"\t[-T use TCP communication, rtl-ais is tcp server ( -h is ignored)\n"
 		"\t[-t time to keep ais messages in sec, using tcp listener (default: 15)\n"
+		"\t[-k keep TCP socket open and write new messages to it as they arrive\n"
 		"\t[-n log NMEA sentences to console (stderr) (default off)]\n"
 		"\t[-I add sample index to NMEA messages (default off)]\n"
 		"\t[-L log sound levels to console (stderr) (default off)]\n\n"
@@ -105,7 +106,7 @@ int main(int argc, char **argv)
         config.host = strdup("127.0.0.1");
         config.port = strdup("10110");
         
-	while ((opt = getopt(argc, argv, "l:r:s:o:EODd:g:p:RATIt:P:h:nLS:?")) != -1)
+	while ((opt = getopt(argc, argv, "l:r:s:o:EODd:g:p:RATIkt:P:h:nLS:?")) != -1)
 	{
 		switch (opt) {
 		case 'l':
@@ -152,12 +153,15 @@ int main(int argc, char **argv)
 		case 'P':
 			config.port=strdup(optarg);
 			break;
-                case 'T':
-                        config.use_tcp_listener=1;
-                        break;
-                case 't':
-                        config.tcp_keep_ais_time = atoi(optarg);
-                        break;
+		case 'T':
+			config.use_tcp_listener=1;
+			break;
+		case 't':
+			config.tcp_keep_ais_time = atoi(optarg);
+			break;
+		case 'k':
+			config.tcp_stream_forever = 1;
+			break;
 		case 'h':
 			config.host=strdup(optarg);
 			break;

--- a/main.c
+++ b/main.c
@@ -76,7 +76,7 @@ void usage(void)
 static volatile int do_exit = 0;
 static void sighandler(int signum)
 {
-        signum = signum;
+        (void)(signum); // unused argument
 	fprintf(stderr, "Signal caught, exiting!\n");
 	do_exit = 1;
 }

--- a/rtl_ais.c
+++ b/rtl_ais.c
@@ -648,7 +648,7 @@ int rtl_ais_isactive(struct rtl_ais_context *ctx)
 
 const char *rtl_ais_next_message(struct rtl_ais_context *ctx)
 {
-        ctx = ctx; //unused for now
+        (void)(ctx); //unused for now
         return aisdecoder_next_message();
 }
 

--- a/rtl_ais.c
+++ b/rtl_ais.c
@@ -471,6 +471,7 @@ void rtl_ais_default_config(struct rtl_ais_config *config)
 	config->dc_filter=1;
         config->edge = 0;
         config->use_tcp_listener = 0, config->tcp_keep_ais_time = 15;
+		config->tcp_stream_forever = 0;
 	config->use_internal_aisdecoder=1;
 	config->seconds_for_decoder_stats=0;
         /* Aisdecoder */
@@ -589,7 +590,7 @@ struct rtl_ais_context *rtl_ais_start(struct rtl_ais_config *config)
 		}
 	}
 	else{ // Internal AIS decoder
-            int ret=init_ais_decoder(config->host,config->port,config->show_levels,config->debug_nmea,ctx->stereo.bl_len,config->seconds_for_decoder_stats, config->use_tcp_listener, config->tcp_keep_ais_time, config->add_sample_num);
+            int ret=init_ais_decoder(config->host,config->port,config->show_levels,config->debug_nmea,ctx->stereo.bl_len,config->seconds_for_decoder_stats, config->use_tcp_listener, config->tcp_keep_ais_time, config->tcp_stream_forever, config->add_sample_num);
 		if(ret != 0){
 			fprintf(stderr,"Error initializing built-in AIS decoder\n");
 			rtlsdr_cancel_async(ctx->dev);

--- a/rtl_ais.h
+++ b/rtl_ais.h
@@ -27,7 +27,7 @@ struct rtl_ais_config
 
     int oversample, dc_filter, use_internal_aisdecoder;
     int seconds_for_decoder_stats;
-    int use_tcp_listener, tcp_keep_ais_time;
+    int use_tcp_listener, tcp_keep_ais_time, tcp_stream_forever;
     /* Aisdecoder */
     int	show_levels, debug_nmea;
     char *port, *host, *filename;

--- a/tcp_listener/tcp_listener.h
+++ b/tcp_listener/tcp_listener.h
@@ -8,7 +8,7 @@
 #define MAX_TCP_CONNECTIONS 100
 
 // Prototypes
-int initTcpSocket( const char *portnumber, int debug_nmea, int tcp_keep_ais_time);
+int initTcpSocket( const char *portnumber, int debug_nmea, int tcp_keep_ais_time, int tcp_stream_forever);
 int add_nmea_ais_message(const char * mess, unsigned int length);
 void closeTcpSocket();
 


### PR DESCRIPTION
This change set adds the `-k` flag, which affects the TCP listener. When `-k` is given, the TCP socket will continue to publish newly-decoded messages to any connected clients.

I've tried to keep unnecessary diffs to a minimum. Here's a summary of the major parts of the change:

#### `typedef struct t_sockIo {...}`

The struct which tracks open TCP clients is extended to add `int msgpipe[2]`. These will store two file descriptors, as created by [`pipe(2)`](https://man7.org/linux/man-pages/man2/pipe.2.html), for the decoder thread to publish to the connection thread. This pipe is created when a new client connects, and destroyed upon disconnect.

#### `add_nmea_ais_message(..)`

When a new message is decoded, _and_ the global `_tcp_stream_forever` option is set, this method is extended to publish the message to all connected clients. It does do by [`write(2)`ing](https://man7.org/linux/man-pages/man2/write.2.html) to the `msgpipe` fd.

#### `handle_remote_close(..)`

This method continues to service remote TCP clients. After publishing buffered messages (existing functionality which is unchanged), it waits on a blocking [`pselect(2)`](https://linux.die.net/man/2/pselect) loop for one of two things to happen:

* New data is available on the read fd of `msgpipe`. It writes it out to the tcp socket.
* New data arrives from the tcp socket. By previous convention, this causes the server to close the socket.
    * It's not clear to me if that behavior remains necessary here; i.e., we could ignore reads and let the client close when it wants.

When `-k` is _not_ specified, no data is ever published to `msgpipe`; so the existing behavior remains intact.

#### Other/unrelated changes

There are two other commits here which address minor/unrelated things I ran into. It might be easier to review by looking at commits one at a time, which should be coherent.