### PR TITLE
Adding Dockerfile for building containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Can't use buster-slim because it needs librtlsdr-dev 0.5.3
 # See https://github.com/dgiardini/rtl-ais/issues/32
 FROM debian:stretch-slim
+LABEL "name"="rtl-ais" \
+  "description"="AIS ship decoding using an RTL-SDR dongle" \
+  "author"="Bryan Klofas KF6ZEO"
 
 ENV APP=/usr/src/app
 
@@ -9,17 +12,16 @@ WORKDIR $APP
 COPY . $APP
 
 RUN apt-get update && apt-get install -y \
-git \
-rtl-sdr \
-librtlsdr-dev \
-make \
-build-essential \
-pkg-config \
-libusb-1.0-0-dev \
-&& make \ 
-&& rm -rf /var/lib/apt/lists/*
+  rtl-sdr \
+  librtlsdr-dev \
+  libusb-1.0-0-dev \
+  make \
+  build-essential \
+  pkg-config \
+  && make \ 
+  && apt-get remove -y make build-essential pkg-config \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/*
 
 CMD $APP/rtl_ais -n
-
-#EXPOSE 10110/udp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
+# Can't use buster-slim because it needs librtlsdr-dev 0.5.3
+# See https://github.com/dgiardini/rtl-ais/issues/32
 FROM debian:stretch-slim
 
-ENV VER=${VER:-master} \
-    REPO=https://github.com/dgiardini/rtl-ais.git \
-    APP=/usr/src/app \
-    GIT_SSL_NO_VERIFY=true
+ENV APP=/usr/src/app
 
 WORKDIR $APP
+
+COPY . $APP
 
 RUN apt-get update && apt-get install -y \
 git \
@@ -15,8 +16,8 @@ make \
 build-essential \
 pkg-config \
 libusb-1.0-0-dev \
-&&  git clone -b $VER $REPO $APP \
-&&  make
+&& make \ 
+&& rm -rf /var/lib/apt/lists/*
 
 CMD $APP/rtl_ais -n
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:stretch-slim
+
+ENV VER=${VER:-master} \
+    REPO=https://github.com/dgiardini/rtl-ais.git \
+    APP=/usr/src/app \
+    GIT_SSL_NO_VERIFY=true
+
+WORKDIR $APP
+
+RUN apt-get update && apt-get install -y \
+git \
+rtl-sdr \
+librtlsdr-dev \
+make \
+build-essential \
+pkg-config \
+libusb-1.0-0-dev \
+&&  git clone -b $VER $REPO $APP \
+&&  make
+
+CMD $APP/rtl_ais -n
+
+#EXPOSE 10110/udp
+

--- a/README.md
+++ b/README.md
@@ -102,6 +102,38 @@ specfic dongle you have (aka ppm error), and pass that number as parameter
 of rtl-ais.
 
 
+Docker Container
+----------------
+Run rtl-ais in a docker container. No dependencies to install. Total container size is approximately 75 MB.
+
+Two options: Either download and run a pre-built docker container, or you can built the container locally.
+
+ 1. To test things out: `docker run -it --rm --device=/dev/bus/usb ghcr.io/bklofas/rtl-ais:latest`
+    * This image will run by default `./rtl_ais -n`, showing the received packets on STDOUT.
+    * Make sure at least one RTL-SDR dongle is connected.
+    * Startup messages and decoded packets will display in the terminal. Ctrl-C to kill.
+
+ 1. For a more permanent setup, run the container in the background and add any options you want: `docker run -d --name rtl-ais --restart=unless-stopped --log-driver=local --network=host --device=/dev/bus/usb ghcr.io/bklofas/rtl-ais:latest ./rtl_ais -n -d 00000002 -h 127.0.0.1 -P 10110`
+    * -d: Start this container in daemon/background mode.
+    * --name: Name this anything you want.
+    * --restart: Automatically restart the container if something happens (reboot, USB problem), unless you have manually stopped the container (with `docker stop rtl-ais`).
+    * --log-driver: By default, docker uses the json log driver which will fill up your harddrive, depending on how busy your station is. local log driver defaults to 100MB of saved logs, and automatically rotates them.
+    * --network: Allows the container to talk to the internet, if you are sending the packets to an online service.
+    * --device: Allows the container to talk to the USB bus to access the RTL-SDR dongle.
+    * ./rtl_ais: Same command-line options as above.
+    * View the startup messages and decoded packets with `docker logs --follow rtl-ais`
+
+Building the container:
+
+ * `git clone https://github.com/bklofas/rtl-ais.git` the repository, then from the folder `docker build -t rtl-ais .`
+ *  Or, build the container without cloning the repository: `docker build https://github.com/bklofas/rtl-ais.git`
+
+Other tips and tricks:
+
+ * If you have the `-n` flag, view the decoded AIS packets in real-time with `docker logs --follow rtl-ais`
+ * If you are only sending packets to one internet service (such as martinetraffic.com), you can use the `-h` and `-P` options that they provide.
+
+
 Testing
 -------
 

--- a/README.md
+++ b/README.md
@@ -104,22 +104,26 @@ of rtl-ais.
 
 Docker Container
 ----------------
-Run rtl-ais in a docker container. No dependencies to install. Total container size is approximately 75 MB.
+Now you can run rtl-ais in a docker container. No dependencies to install. Total container size is approximately 75 MB. Get/install docker [here](https://docs.docker.com/get-docker/).
 
-Two options: Either download and run a pre-built docker container, or you can built the container locally.
+Two options for obtaining the container: Either download and run a pre-built container, or build the container locally.
 
- 1. To test things out: `docker run -it --rm --device=/dev/bus/usb ghcr.io/bklofas/rtl-ais:latest`
-    * This image will run by default `./rtl_ais -n`, showing the received packets on STDOUT.
+ 1. Just to test things out: `docker run -it --rm --device=/dev/bus/usb ghcr.io/bklofas/rtl-ais:latest`
+    * This downloads a pre-built container from the Github container registry.
+    * This image will run by default `./rtl_ais -n`, showing the received packets on STDOUT. All other default values.
+    * You can add other ./rtl-sdr options, see below.
     * Make sure at least one RTL-SDR dongle is connected.
-    * Startup messages and decoded packets will display in the terminal. Ctrl-C to kill.
+    * Startup messages and decoded packets will display in the terminal.
+    * Ctrl-C to kill.
+    * Using the `--rm` flag will delete the container when you kill it. Otherwise, it will stay around until you prune.
 
  1. For a more permanent setup, run the container in the background and add any options you want: `docker run -d --name rtl-ais --restart=unless-stopped --log-driver=local --network=host --device=/dev/bus/usb ghcr.io/bklofas/rtl-ais:latest ./rtl_ais -n -d 00000002 -h 127.0.0.1 -P 10110`
     * -d: Start this container in daemon/background mode.
     * --name: Name this anything you want.
-    * --restart: Automatically restart the container if something happens (reboot, USB problem), unless you have manually stopped the container (with `docker stop rtl-ais`).
-    * --log-driver: By default, docker uses the json log driver which will fill up your harddrive, depending on how busy your station is. local log driver defaults to 100MB of saved logs, and automatically rotates them.
-    * --network: Allows the container to talk to the internet, if you are sending the packets to an online service.
-    * --device: Allows the container to talk to the USB bus to access the RTL-SDR dongle.
+    * --restart=unless-stopped: Automatically restart the container if something happens (reboot, USB problem), unless you have manually stopped the container (with `docker stop rtl-ais`).
+    * --log-driver=local: By default, docker uses the json log driver which may fill up your harddrive, depending on how busy your station is. `local` log driver defaults to 100MB of saved logs, and automatically rotates them.
+    * --network=host: Allows the container to talk to the internet, if you are sending the packets to an online service.
+    * --device=: Allows the container to talk to the USB bus to access the RTL-SDR dongle.
     * ./rtl_ais: Same command-line options as above.
     * View the startup messages and decoded packets with `docker logs --follow rtl-ais`
 
@@ -131,7 +135,7 @@ Building the container:
 Other tips and tricks:
 
  * If you have the `-n` flag, view the decoded AIS packets in real-time with `docker logs --follow rtl-ais`
- * If you are only sending packets to one internet service (such as martinetraffic.com), you can use the `-h` and `-P` options that they provide.
+ * If you are only sending packets to one internet service (such as marinetraffic.com), you can use the `-h` and `-P` options that they send you.
 
 
 Testing


### PR DESCRIPTION
Hey @dgiardini  , I've been using rtl-ais for a while, it works great! I created a dockerfile for this project, based on debian-slim, and the total size is about 75 MB. I have tested this out on x86-64, it works well.

I also uploaded the built container to the github container registry under my username. I'm not sure how you want to handle this with regards to the README. You can keep it as is (referencing ghcr.io/bklofas), or build a container and upload under your github username (or dockerhub), or remove the pre-built container references completely and just tell people to build the containers themselves. Either is totally fine with me.

Thanks!