### PR TITLE
Add paths for Homebrew dependencies on Apple Silicon to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ LIBUSB_LIB=/tmp/libusb/lib
 
 ifeq ($(UNAME),Darwin)
 #Conditional for OSX
-CFLAGS+= -I/usr/local/include/ -I$(LIBUSB_INCLUDE) -I$(RTLSDR_INCLUDE)
-LDFLAGS+= -L/usr/local/lib -L$(LIBUSB_LIB) -L$(RTLSDR_LIB) -lrtlsdr -lusb-1.0 
+CFLAGS+= -I/usr/local/include/ -I/opt/homebrew/include -I$(LIBUSB_INCLUDE) -I$(RTLSDR_INCLUDE)
+LDFLAGS+= -L/usr/local/lib -L/opt/homebrew/lib -L$(LIBUSB_LIB) -L$(RTLSDR_LIB) -lrtlsdr -lusb-1.0 
 else
 #Conditional for Windows
 CFLAGS+=-I $(LIBUSB_INCLUDE) -I $(RTLSDR_INCLUDE)


### PR DESCRIPTION
On the current Apple Silicon machines Homebrew moved from `/usr/local` to `/opt/homebrew` so the headers and libraries are not found there
The original paths still must be there as they are used on Intel macs or when everything is built locally.