### PR TITLE
Fix Makefile building error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CFLAGS?=-O2 -g -Wall  
 CFLAGS+= -I./aisdecoder -I ./aisdecoder/lib -I./tcp_listener 
-LD_EXTRA_PATHS= -L /usr/lib/arm-linux-gnueabihf/ -L /usr/lib/i386-linux-gnu/ -L /usr/lib/x86_64-linux-gnu/
+LD_EXTRA_PATHS= -L /usr/lib/arm-linux-gnueabihf -L /usr/lib/i386-linux-gnu -L /usr/lib/x86_64-linux-gnu
 LDFLAGS+=-lpthread -lm $(LD_EXTRA_PATHS)
 ifeq ($(PREFIX),)
     PREFIX := /usr/local
@@ -74,7 +74,7 @@ clean:
 	rm -f $(OBJECTS) $(EXECUTABLE) $(EXECUTABLE).exe
 
 install:
-	install -d -m 755 $(DESTDIR)/$(PREFIX)/bin
-	install -m 755 $(EXECUTABLE) "$(DESTDIR)/$(PREFIX)/bin/"
+	install -d -m 755 $(PREFIX)/bin
+	install -m 755 $(EXECUTABLE) "$(PREFIX)/bin/"
 
 


### PR DESCRIPTION
Hello, I was getting those error while building on Ubuntu 20.04
```
julien@julien:/tmp/rtl-ais$ make -j20
cc -c rtl_ais.c -o rtl_ais.o -O2 -g -Wall   -I./aisdecoder -I ./aisdecoder/lib -I./tcp_listener  -I/usr/local/include/ -I/usr/include/libusb-1.0
cc -c convenience.c -o convenience.o -O2 -g -Wall   -I./aisdecoder -I ./aisdecoder/lib -I./tcp_listener  -I/usr/local/include/ -I/usr/include/libusb-1.0
cc -c aisdecoder/lib/filter.c -o aisdecoder/lib/filter.o -O2 -g -Wall   -I./aisdecoder -I ./aisdecoder/lib -I./tcp_listener  -I/usr/local/include/ -I/usr/include/libusb-1.0
cc -c tcp_listener/tcp_listener.c -o tcp_listener/tcp_listener.o -O2 -g -Wall   -I./aisdecoder -I ./aisdecoder/lib -I./tcp_listener  -I/usr/local/include/ -I/usr/include/libusb-1.0
cc main.o rtl_ais.o convenience.o ./aisdecoder/aisdecoder.o ./aisdecoder/sounddecoder.o ./aisdecoder/lib/receiver.o ./aisdecoder/lib/protodec.o ./aisdecoder/lib/hmalloc.o ./aisdecoder/lib/filter.o ./tcp_listener/tcp_listener.o -o rtl_ais -lpthread -lm -L /usr/lib/arm-linux-gnueabihf/ -L /usr/lib/i386-linux-gnu/ -L /usr/lib/x86_64-linux-gnu/ -L/usr/local/lib -lrtlsdr -lusb-1.0
/usr/bin/ld: skipping incompatible /usr/lib/i386-linux-gnu//libgcc_s.so.1 when searching for libgcc_s.so.1
/usr/bin/ld: skipping incompatible /usr/lib/i386-linux-gnu//libgcc_s.so.1 when searching for libgcc_s.so.1
```
and
```
julien@julien:/tmp/rtl-ais$ sudo make install 
install -d -m 755 //usr/local/bin
install -m 755 rtl_ais "//usr/local/bin/"
```

Locations were wrong as `$(DESTDIR)` wasn't used, and there was a `/` to remove. It's building correctly now.